### PR TITLE
Update to set a provider init global error handler [ref #6]

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -8,7 +8,8 @@ var (
 	// ErrNoDefault means that no default keyring provider has been found
 	ErrNoDefault = errors.New("keyring: No suitable keyring provider found (check your build flags)")
 
-	defaultProvider provider
+	defaultProvider   provider
+	providerInitError error
 )
 
 // provider provides a simple interface to keychain sevice
@@ -20,17 +21,23 @@ type provider interface {
 // Get gets the password for a paricular Service and Username using the
 // default keyring provider.
 func Get(service, username string) (string, error) {
-	if defaultProvider == nil {
+	if providerInitError != nil {
+		return "", providerInitError
+	} else if defaultProvider == nil {
 		return "", ErrNoDefault
 	}
+
 	return defaultProvider.Get(service, username)
 }
 
 // Set sets the password for a particular Service and Username using the
 // default keyring provider.
 func Set(service, username, password string) error {
-	if defaultProvider == nil {
+	if providerInitError != nil {
+		return providerInitError
+	} else if defaultProvider == nil {
 		return ErrNoDefault
 	}
+
 	return defaultProvider.Set(service, username, password)
 }

--- a/keyring_linux.go
+++ b/keyring_linux.go
@@ -5,7 +5,6 @@ package keyring
 import (
 	"fmt"
 	dbus "github.com/guelfey/go.dbus"
-	"os"
 )
 
 const (
@@ -144,7 +143,7 @@ func (s *ssProvider) Set(c, u, p string) error {
 func init() {
 	conn, err := dbus.SessionBus()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "keyring/dbus: Error connecting to dbus session, not registering SecretService provider")
+		providerInitError = fmt.Errorf("keyring/dbus: Error connecting to dbus session, not registering SecretService provider")
 		return
 	}
 	srv := conn.Object(ssServiceName, ssServicePath)
@@ -152,7 +151,7 @@ func init() {
 
 	// Everything should implement dbus peer, so ping to make sure we have an object...
 	if session, err := p.openSession(); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to open dbus session %s: %s\n", srv, err)
+		providerInitError = fmt.Errorf("Unable to open dbus session %s: %s\n", srv, err)
 		return
 	} else {
 		session.Call(fmt.Sprint(ssSessionIface, "Close"), 0)


### PR DESCRIPTION
I've added a global `providerInitError` to handle errors during the dbus session init in _keyring_linux_ provider. That way, keyring `Get` and `Set` methods are able to check on errors during the init (without logging).

I think something cleaner could have been made in terms of design. But I tried to stick to the way you made it to fit with the whole codebase.

Let me know what you think.
