### PR TITLE
Avoid using init() fucntions when connecting to DBus

### DIFF
--- a/gnome_keyring_linux.go
+++ b/gnome_keyring_linux.go
@@ -91,6 +91,6 @@ func (p gnomeKeyring) Get(Service string, Username string) (string, error) {
 	return C.GoString((*C.char)(pw)), nil
 }
 
-func init() {
-	defaultProvider = gnomeKeyring{}
+func initializeProvider() (provider, error) {
+	return gnomeKeyring{}, nil
 }

--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -49,6 +49,6 @@ func (p osxProvider) Set(Service, Username, Password string) error {
 	return nil
 }
 
-func init() {
-	defaultProvider = osxProvider{}
+func initializeProvider() (provider, error) {
+	return osxProvider{}, nil
 }

--- a/keyring_linux.go
+++ b/keyring_linux.go
@@ -4,6 +4,7 @@ package keyring
 
 import (
 	"fmt"
+
 	dbus "github.com/guelfey/go.dbus"
 )
 
@@ -140,22 +141,12 @@ func (s *ssProvider) Set(c, u, p string) error {
 	return nil
 }
 
-func init() {
+func initializeProvider() (provider, error) {
 	conn, err := dbus.SessionBus()
 	if err != nil {
-		providerInitError = fmt.Errorf("keyring/dbus: Error connecting to dbus session, not registering SecretService provider")
-		return
+		return nil, err
 	}
 	srv := conn.Object(ssServiceName, ssServicePath)
 	p := &ssProvider{conn, srv}
-
-	// Everything should implement dbus peer, so ping to make sure we have an object...
-	if session, err := p.openSession(); err != nil {
-		providerInitError = fmt.Errorf("Unable to open dbus session %s: %s\n", srv, err)
-		return
-	} else {
-		session.Call(fmt.Sprint(ssSessionIface, "Close"), 0)
-	}
-
-	defaultProvider = p
+	return p, nil
 }


### PR DESCRIPTION
We have seen this hang processes for ~30 seconds just by importing this module.  This PR changes everything to use a sync.Once function, but only once Get/Set are called.