### PR TITLE
keyring_darwin.go: handle funky passwords

### DIFF
--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"strings"
 	"syscall"
 )
 
@@ -11,6 +12,10 @@ type osxProvider struct {
 }
 
 var pwRe = regexp.MustCompile(`password:\s+(?:0x[A-Fa-f0-9]+\s+)?"(.+)"`)
+
+func unescape(raw string) string {
+	return strings.Replace(raw, "\\134", "\\", -1)
+}
 
 func (p osxProvider) Get(Service, Username string) (string, error) {
 	args := []string{"find-generic-password",
@@ -31,7 +36,7 @@ func (p osxProvider) Get(Service, Username string) (string, error) {
 	if len(matches) != 2 {
 		return "", ErrNotFound
 	}
-	return matches[1], nil
+	return unescape(matches[1]), nil
 }
 
 func (p osxProvider) Set(Service, Username, Password string) error {

--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -10,7 +10,7 @@ import (
 type osxProvider struct {
 }
 
-var pwRe = regexp.MustCompile("password: \"(.+)\"")
+var pwRe = regexp.MustCompile(`password:\s+(?:0x[A-Fa-f0-9]+\s+)?"(.+)"`)
 
 func (p osxProvider) Get(Service, Username string) (string, error) {
 	args := []string{"find-generic-password",

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -5,26 +5,32 @@ import (
 	"testing"
 )
 
-func TestBasicSetGet(t *testing.T) {
+func AssertPasswordSticks(t *testing.T, user, password string) {
 	var (
 		pw  string
 		err error
 	)
-	pw, err = Get("keyring-test", "jack")
+	pw, err = Get("keyring-test", user)
 	if err != nil {
 		// ok on initial invokation
 		fmt.Println("Get() error:", err)
 	}
-	err = Set("keyring-test", "jack", "test")
+	err = Set("keyring-test", user, password)
 	if err != nil {
 		t.Error("Set() error:", err)
 	}
-	pw, err = Get("keyring-test", "jack")
+	pw, err = Get("keyring-test", user)
 	if err != nil {
-		t.Error("Get() error:", err)
+		t.Errorf("Get() error for %s: %s", user, err)
 	}
 
-	if pw != "test" {
+	if pw != password {
 		fmt.Errorf("expected 'test', got '%s'", pw)
+		t.Fail()
 	}
+}
+
+func TestBasicSetGet(t *testing.T) {
+	AssertPasswordSticks(t, "jack", "pass")
+	AssertPasswordSticks(t, "alice", "cr4zyp!s\\%")
 }

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -1,11 +1,10 @@
 package keyring
 
 import (
-	"fmt"
 	"testing"
 )
 
-func AssertPasswordSticks(t *testing.T, user, password string) {
+func assertPasswordSticks(t *testing.T, user, password string) {
 	var (
 		pw  string
 		err error
@@ -13,11 +12,11 @@ func AssertPasswordSticks(t *testing.T, user, password string) {
 	pw, err = Get("keyring-test", user)
 	if err != nil {
 		// ok on initial invokation
-		fmt.Println("Get() error:", err)
+		t.Errorf("Initial Get() error for %s: %s", user, err)
 	}
 	err = Set("keyring-test", user, password)
 	if err != nil {
-		t.Error("Set() error:", err)
+		t.Errorf("Set() error for %s: %s", user, err)
 	}
 	pw, err = Get("keyring-test", user)
 	if err != nil {
@@ -25,12 +24,21 @@ func AssertPasswordSticks(t *testing.T, user, password string) {
 	}
 
 	if pw != password {
-		fmt.Errorf("expected 'test', got '%s'", pw)
-		t.Fail()
+		t.Errorf("expected '%s' for %s, got '%s'", password, user, pw)
 	}
 }
 
 func TestBasicSetGet(t *testing.T) {
-	AssertPasswordSticks(t, "jack", "pass")
-	AssertPasswordSticks(t, "alice", "cr4zyp!s\\%")
+	cases := []struct {
+		user     string
+		password string
+	}{
+		{"jack", "foo"},
+		{"jill", "bar"},
+		{"alice", "cr4zyp!s\\%"},
+		{"punctuator", "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"},
+	}
+	for _, testCase := range cases {
+		assertPasswordSticks(t, testCase.user, testCase.password)
+	}
 }

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -12,7 +12,7 @@ func assertPasswordSticks(t *testing.T, user, password string) {
 	pw, err = Get("keyring-test", user)
 	if err != nil {
 		// ok on initial invokation
-		t.Errorf("Initial Get() error for %s: %s", user, err)
+		t.Logf("(expected) Initial Get() error for %s: %s", user, err)
 	}
 	err = Set("keyring-test", user, password)
 	if err != nil {

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -37,6 +37,8 @@ func TestBasicSetGet(t *testing.T) {
 		{"jill", "bar"},
 		{"alice", "cr4zyp!s\\%"},
 		{"punctuator", "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"},
+		{"pierre", "bérets"},
+		{"unibomba", "I❤Unicode"},
 	}
 	for _, testCase := range cases {
 		assertPasswordSticks(t, testCase.user, testCase.password)


### PR DESCRIPTION
The 'security' command adds a hex representation of the password if it contains
certain characters in it.  Without the updated Regex, it fails to retrieve the
password, and the test fails with:

	$ go test .
	Get() error: keyring: Password not found
	--- FAIL: TestBasicSetGet (0.21s)
		keyring_test.go:24: Get() error for alice: keyring: Password not found
	FAIL
	FAIL	src/github.com/tmc/keyring	0.217s