### PR TITLE
Uses aliases/default rather then collection/Default to find the default keyring.

### DIFF
--- a/keyring_linux.go
+++ b/keyring_linux.go
@@ -10,7 +10,7 @@ import (
 const (
 	ssServiceName     = "org.freedesktop.secrets"
 	ssServicePath     = "/org/freedesktop/secrets"
-	ssCollectionPath  = "/org/freedesktop/secrets/collection/Default"
+	ssCollectionPath  = "/org/freedesktop/secrets/aliases/default"
 	ssServiceIface    = "org.freedesktop.Secret.Service."
 	ssSessionIface    = "org.freedesktop.Secret.Session."
 	ssCollectionIface = "org.freedesktop.Secret.Collection."


### PR DESCRIPTION
This allows tests and applications to work on systems where the default keyring
is not literally named "Default" (i.e. Ubuntu/Mint systems where it is named
"Login".

Resolves #11.

This is just a PR of the workaround over in https://github.com/acsellers/keyring/commit/d629033c36dc784cb8d2b03da042ab576bc1efa3 to hopefully drive through to a solution.